### PR TITLE
Removed lib (closes #22)

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,8 +7,11 @@ const fs = require('fs');
 const path = require('path');
 const serveFavicon = require('serve-favicon');
 
-// Import custom modules
-const importJSON = require('./lib/importJSON');
+// Initialise library path
+const libPath = process.env.LIB_PATH ?? '../lib';
+
+// Import library functions
+const { helpers: { ConfigHelper } } = require(libPath);
 
 /**
  * loadRoutes() Loads all of the routes from /routers into a map
@@ -34,7 +37,7 @@ function main() {
 	const app = express();
 
 	// Import configuration
-	const serverOptions = importJSON('server');
+	const serverOptions = ConfigHelper.importJSON(path.join(__dirname, 'config'), 'server');
 
 	// Set up handlebars templating engine
 	app.engine(

--- a/config/site.sample.json
+++ b/config/site.sample.json
@@ -1,5 +1,4 @@
 {
 	"title": "Org",
-	"frameworkURL": null,
-	"libraryPath": "../lib/"
+	"frameworkURL": null
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,9 +5,14 @@ const { src, dest, series } = require('gulp');
 const rename = require('gulp-rename');
 const fs = require('fs');
 const path = require('path');
-const importJSON = require(path.join(__dirname, 'lib', 'importJSON'));
 const prompt = require('prompt-sync')({ sigint: true });
 const del = require('del');
+
+// Initialise library path
+const libPath = process.env.LIB_PATH ?? '../lib';
+
+// Import library functions
+const { helpers: { ConfigHelper } } = require(libPath);
 
 function cleanConfig() {
 	const configFiles = fs.readdirSync(path.join(__dirname, 'config'))
@@ -46,7 +51,7 @@ function setConfig(cb) {
 	console.log(chalk.green(message));
 
 	for (const file of configFiles) {
-		const contents = importJSON(file);
+		const contents = ConfigHelper.importJSON(path.join(__dirname, 'config'), file);
 
 		console.log(`\nConsidering ${file}.json`);
 		console.log('Current contents:');


### PR DESCRIPTION
With the Library repository now live and populated, we needed to migrate away from local copies of library functions in this repo.

This change introduces a new environment variable that can be configured to set the path to find the Library repository, or if it is not set then it uses `../lib` by default.

This requires #23 to be merged first, then I'll take it out of draft.