### PR TITLE
Updated template to load the framework stylesheet and site title from config

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,10 @@ const serveFavicon = require('serve-favicon');
 const libPath = process.env.LIB_PATH ?? '../lib';
 
 // Import library functions
-const { helpers: { ConfigHelper } } = require(libPath);
+const { helpers: { ConfigHelper, HandlebarsHelper } } = require(libPath);
+
+//set global base dir
+global.__approot = __dirname;
 
 /**
  * loadRoutes() Loads all of the routes from /routers into a map
@@ -43,7 +46,8 @@ function main() {
 	app.engine(
 		'hbs',
 		engine({
-			extname: '.hbs'
+			extname: '.hbs',
+			helpers: HandlebarsHelper
 		})
 	);
 	app.set('view engine', 'hbs');

--- a/config/site.sample.json
+++ b/config/site.sample.json
@@ -1,4 +1,4 @@
 {
-	"title": "Org",
+	"title": "Website Name",
 	"frameworkURL": null
 }

--- a/views/partials/head.hbs
+++ b/views/partials/head.hbs
@@ -5,5 +5,7 @@
 	<meta http-equiv='X-UA-Compatible' content='IE=edge'>
 
 	<!-- Title -->
-	<title>{{ title }}</title>
+	<title>{{ title }} | {{getConfigValue 'config/site' 'title' 'Website Name'}}</title>
+
+	<link rel="stylesheet" href="{{getConfigValue 'config/site' 'frameworkURL' '/css/framework.css'}}" />
 </head>


### PR DESCRIPTION
Loads config data directly within `Handlebars` templates to save us having to try and pass things around (closes #25 )

Also removed left over `lib` files